### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py
+++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py
@@ -357,7 +357,7 @@ def gyp_main(args):
         home_vars.append('USERPROFILE')
       for home_var in home_vars:
         home = os.getenv(home_var)
-        if home != None:
+        if home is not None:
           home_dot_gyp = os.path.join(home, '.gyp')
           if not os.path.exists(home_dot_gyp):
             home_dot_gyp = None
@@ -465,7 +465,7 @@ def gyp_main(args):
 
   # If ~/.gyp/include.gypi exists, it'll be forcibly included into every
   # .gyp file that's loaded, before anything else is included.
-  if home_dot_gyp != None:
+  if home_dot_gyp is not None:
     default_include = os.path.join(home_dot_gyp, 'include.gypi')
     if os.path.exists(default_include):
       print 'Using overrides found in ' + default_include

--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/ninja.py
+++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/ninja.py
@@ -718,7 +718,7 @@ class NinjaWriter(object):
           elif var == 'name':
             extra_bindings.append(('name', cygwin_munge(basename)))
           else:
-            assert var == None, repr(var)
+            assert var is None, repr(var)
 
         outputs = [self.GypPathToNinja(o, env) for o in outputs]
         if self.flavor == 'win':

--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/xcode.py
+++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/xcode.py
@@ -535,7 +535,7 @@ def ExpandXcodeVariables(string, expansions):
   """
 
   matches = _xcode_variable_re.findall(string)
-  if matches == None:
+  if matches is None:
     return string
 
   matches.reverse()

--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py
+++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/input.py
@@ -154,7 +154,7 @@ def GetIncludedBuildFiles(build_file_path, aux_data, included=None):
   in the list will be relative to the current directory.
   """
 
-  if included == None:
+  if included is None:
     included = []
 
   if build_file_path in included:
@@ -270,7 +270,7 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes,
 def LoadBuildFileIncludesIntoDict(subdict, subdict_path, data, aux_data,
                                   includes, check):
   includes_list = []
-  if includes != None:
+  if includes is not None:
     includes_list.extend(includes)
   if 'includes' in subdict:
     for include in subdict['includes']:
@@ -886,7 +886,7 @@ def ExpandVariables(input, phase, variables, build_file):
             replacement = str(py_module.DoMain(parsed_contents[1:])).rstrip()
           finally:
             os.chdir(oldwd)
-          assert replacement != None
+          assert replacement is not None
         elif command_string:
           raise GypError("Unknown command string '{0!s}' in '{1!s}'.".format(command_string, contents))
         else:
@@ -1047,7 +1047,7 @@ def EvalCondition(condition, conditions_key, phase, variables, build_file):
     else:
       false_dict = None
       i = i + 2
-    if result == None:
+    if result is None:
       result = EvalSingleCondition(
           cond_expr, true_dict, false_dict, phase, variables, build_file)
 
@@ -1126,7 +1126,7 @@ def ProcessConditionsInDict(the_dict, phase, variables, build_file):
     merge_dict = EvalCondition(condition, conditions_key, phase, variables,
                                build_file)
 
-    if merge_dict != None:
+    if merge_dict is not None:
       # Expand variables and nested conditinals in the merge_dict before
       # merging it.
       ProcessVariablesAndConditionsInDict(merge_dict, phase,
@@ -1587,12 +1587,12 @@ class DependencyGraphNode(object):
 
   def DirectDependencies(self, dependencies=None):
     """Returns a list of just direct dependencies."""
-    if dependencies == None:
+    if dependencies is None:
       dependencies = []
 
     for dependency in self.dependencies:
       # Check for None, corresponding to the root node.
-      if dependency.ref != None and dependency.ref not in dependencies:
+      if dependency.ref is not None and dependency.ref not in dependencies:
         dependencies.append(dependency.ref)
 
     return dependencies
@@ -1615,7 +1615,7 @@ class DependencyGraphNode(object):
     public entry point.
     """
 
-    if dependencies == None:
+    if dependencies is None:
       dependencies = []
 
     index = 0

--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcodeproj_file.py
+++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/xcodeproj_file.py
@@ -384,7 +384,7 @@ class XCObject(object):
     hashables = [self.__class__.__name__]
 
     name = self.Name()
-    if name != None:
+    if name is not None:
       hashables.append(name)
 
     hashables.extend(self._hashables)
@@ -630,7 +630,7 @@ class XCObject(object):
     else:
       raise TypeError("Can't make " + value.__class__.__name__ + ' printable')
 
-    if comment != None:
+    if comment is not None:
       printable += ' ' + self._EncodeComment(comment)
 
     return printable
@@ -926,11 +926,11 @@ class XCHierarchicalElement(XCObject):
       # the variable out and make the path be relative to that variable by
       # assigning the variable name as the sourceTree.
       (source_tree, path) = SourceTreeAndPathFromPath(self._properties['path'])
-      if source_tree != None:
+      if source_tree is not None:
         self._properties['sourceTree'] = source_tree
-      if path != None:
+      if path is not None:
         self._properties['path'] = path
-      if source_tree != None and path is None and \
+      if source_tree is not None and path is None and \
          not 'name' in self._properties:
         # The path was of the form "$(SDKROOT)" with no path following it.
         # This object is now relative to that variable, so it has no path
@@ -992,7 +992,7 @@ class XCHierarchicalElement(XCObject):
     # hashables, even though the paths aren't relative to their parents.  This
     # is not expected to be much of a problem in practice.
     path = self.PathFromSourceTreeAndPath()
-    if path != None:
+    if path is not None:
       components = path.split(posixpath.sep)
       for component in components:
         hashables.append(self.__class__.__name__ + '.path')
@@ -1083,9 +1083,9 @@ class XCHierarchicalElement(XCObject):
           (path is None or \
            (not path.startswith('/') and not path.startswith('$'))):
       this_path = xche.PathFromSourceTreeAndPath()
-      if this_path != None and path != None:
+      if this_path is not None and path is not None:
         path = posixpath.join(this_path, path)
-      elif this_path != None:
+      elif this_path is not None:
         path = this_path
       xche = xche.parent
 
@@ -1126,7 +1126,7 @@ class PBXGroup(XCHierarchicalElement):
     # children.
     for child in self._properties.get('children', []):
       child_name = child.Name()
-      if child_name != None:
+      if child_name is not None:
         hashables.append(child_name)
 
     return hashables
@@ -1256,14 +1256,14 @@ class PBXGroup(XCHierarchicalElement):
 
     path_split = path.split(posixpath.sep)
     if len(path_split) == 1 or \
-       ((is_dir or variant_name != None) and len(path_split) == 2) or \
+       ((is_dir or variant_name is not None) and len(path_split) == 2) or \
        not hierarchical:
       # The PBXFileReference or PBXVariantGroup will be added to or gotten from
       # this PBXGroup, no recursion necessary.
       if variant_name is None:
         # Add or get a PBXFileReference.
         file_ref = self.GetChildByPath(path)
-        if file_ref != None:
+        if file_ref is not None:
           assert file_ref.__class__ == PBXFileReference
         else:
           file_ref = PBXFileReference({'path': path})
@@ -1278,7 +1278,7 @@ class PBXGroup(XCHierarchicalElement):
             variant_group_name, grandparent)
         variant_path = posixpath.sep.join(path_split[-2:])
         variant_ref = variant_group_ref.GetChildByPath(variant_path)
-        if variant_ref != None:
+        if variant_ref is not None:
           assert variant_ref.__class__ == PBXFileReference
         else:
           variant_ref = PBXFileReference({'name': variant_name,
@@ -1294,7 +1294,7 @@ class PBXGroup(XCHierarchicalElement):
       # path component.
       next_dir = path_split[0]
       group_ref = self.GetChildByPath(next_dir)
-      if group_ref != None:
+      if group_ref is not None:
         assert group_ref.__class__ == PBXGroup
       else:
         group_ref = PBXGroup({'path': next_dir})
@@ -1322,7 +1322,7 @@ class PBXGroup(XCHierarchicalElement):
       return variant_group_ref
 
     variant_group_properties = {'name': name}
-    if path != None:
+    if path is not None:
       variant_group_properties['path'] = path
     variant_group_ref = PBXVariantGroup(variant_group_properties)
     self.AppendChild(variant_group_ref)
@@ -1382,7 +1382,7 @@ class PBXGroup(XCHierarchicalElement):
       # If the original parent had a name set, keep using it.  If the original
       # parent didn't have a name but the child did, let the child's name
       # live on.  If the name attribute seems unnecessary now, get rid of it.
-      if 'name' in old_properties and old_properties['name'] != None and \
+      if 'name' in old_properties and old_properties['name'] is not None and \
          old_properties['name'] != self.Name():
         self._properties['name'] = old_properties['name']
       if 'name' in self._properties and 'path' in self._properties and \
@@ -1423,7 +1423,7 @@ class XCFileLikeElement(XCHierarchicalElement):
 
     hashables = []
     xche = self
-    while xche != None and isinstance(xche, XCHierarchicalElement):
+    while xche is not None and isinstance(xche, XCHierarchicalElement):
       xche_hashables = xche.Hashables()
       for index in xrange(0, len(xche_hashables)):
         hashables.insert(index, xche_hashables[index])
@@ -1812,7 +1812,7 @@ class XCBuildPhase(XCObject):
     xcfilelikeelement = pbxbuildfile._properties['fileRef']
 
     paths = []
-    if path != None:
+    if path is not None:
       # It's best when the caller provides the path.
       if isinstance(xcfilelikeelement, PBXVariantGroup):
         paths.append(path)
@@ -2273,10 +2273,10 @@ class PBXNativeTarget(XCTarget):
        self._properties['productType'] in self._product_filetypes:
       products_group = None
       pbxproject = self.PBXProjectAncestor()
-      if pbxproject != None:
+      if pbxproject is not None:
         products_group = pbxproject.ProductsGroup()
 
-      if products_group != None:
+      if products_group is not None:
         (filetype, prefix, suffix) = \
             self._product_filetypes[self._properties['productType']]
         # Xcode does not have a distinct type for loadable modules that are
@@ -2604,7 +2604,7 @@ class PBXProject(XCContainerPortal):
     }
 
     (source_tree, path) = SourceTreeAndPathFromPath(path)
-    if source_tree != None and source_tree in source_tree_groups:
+    if source_tree is not None and source_tree in source_tree_groups:
       (group_func, hierarchical) = source_tree_groups[source_tree]
       group = group_func()
       return (group, hierarchical)

--- a/deps/v8/tools/gdb-v8-support.py
+++ b/deps/v8/tools/gdb-v8-support.py
@@ -123,7 +123,7 @@ class V8ValuePrinter(object):
 
 def v8_pretty_printers(val):
   lookup_tag = val.type.tag
-  if lookup_tag == None:
+  if lookup_tag is None:
     return None
   elif lookup_tag == 'v8value':
     return V8ValuePrinter(val)

--- a/deps/v8/tools/gen-postmortem-metadata.py
+++ b/deps/v8/tools/gen-postmortem-metadata.py
@@ -586,7 +586,7 @@ def emit_config():
                 bklass = get_base_class(klassname);
                 if (bklass != 'Object'):
                         continue;
-                if (pklass == None):
+                if (pklass is None):
                         continue;
 
                 consts.append({

--- a/deps/v8/tools/grokdump.py
+++ b/deps/v8/tools/grokdump.py
@@ -1758,7 +1758,7 @@ class InspectionInfo(object):
 
   def get_style_class_string(self, address):
     style = self.get_style_class(address)
-    if style != None:
+    if style is not None:
       return " class=\"{0!s}\" ".format(style)
     else:
       return ""
@@ -2458,7 +2458,7 @@ class InspectionWebFormatter(object):
       self.td_from_address(f, maybe_address)
       f.write(":&nbsp;{0!s}&nbsp;</td>\n".format(straddress))
       f.write("  <td>")
-      if maybe_address != None:
+      if maybe_address is not None:
         self.output_comment_box(
             f, "sv-" + self.reader.FormatIntPtr(slot), maybe_address)
       f.write("  </td>\n")

--- a/deps/v8/tools/presubmit.py
+++ b/deps/v8/tools/presubmit.py
@@ -76,7 +76,7 @@ def CppLintWorker(command):
     error_count = -1
     while True:
       out_line = process.stderr.readline()
-      if out_line == '' and process.poll() != None:
+      if out_line == '' and process.poll() is not None:
         if error_count == -1:
           print "Failed to process {0!s}".format(command.pop())
           return 1

--- a/deps/v8/tools/process-heap-prof.py
+++ b/deps/v8/tools/process-heap-prof.py
@@ -64,7 +64,7 @@ def ProcessLogFile(filename, options):
       for row in logreader:
         if row[0] == 'heap-sample-begin' and row[1] == 'Heap':
           sample_time = float(row[3])/1000.0
-          if first_call_time == None:
+          if first_call_time is None:
             first_call_time = sample_time
           sample_time -= first_call_time
           print('BEGIN_SAMPLE {0:.2f}'.format(sample_time))

--- a/deps/v8/tools/testrunner/server/compression.py
+++ b/deps/v8/tools/testrunner/server/compression.py
@@ -56,7 +56,7 @@ class Receiver(object):
     self._next = self._GetNext()
 
   def IsDone(self):
-    return self._next == None
+    return self._next is None
 
   def Current(self):
     return self._next

--- a/tools/genv8constants.py
+++ b/tools/genv8constants.py
@@ -62,7 +62,7 @@ def out_reset():
 
 def out_define():
   global curr_sym, curr_val, curr_octet, outfile, octets
-  if curr_sym != None:
+  if curr_sym is not None:
     wrapped_val = curr_val & 0xffffffff;
     if curr_val & 0x80000000 != 0:
       wrapped_val = 0x100000000 - wrapped_val;
@@ -72,7 +72,7 @@ def out_define():
   out_reset();
 
 for line in pipe:
-  if curr_sym != None:
+  if curr_sym is not None:
     #
     # This bit of code has nasty knowledge of the objdump text output
     # format, but this is the most obvious robust approach.  We could almost
@@ -94,14 +94,14 @@ for line in pipe:
       curr_octet += 1;
 
   match = pattern.match(line)
-  if match == None:
+  if match is None:
     continue;
 
   # Print previous symbol
   out_define();
 
   v8match = v8dbg.match(match.group(2));
-  if v8match != None:
+  if v8match is not None:
     out_reset();
     curr_sym = match.group(2);
 

--- a/tools/gyp/pylib/gyp/__init__.py
+++ b/tools/gyp/pylib/gyp/__init__.py
@@ -368,7 +368,7 @@ def gyp_main(args):
         home_vars.append('USERPROFILE')
       for home_var in home_vars:
         home = os.getenv(home_var)
-        if home != None:
+        if home is not None:
           home_dot_gyp = os.path.join(home, '.gyp')
           if not os.path.exists(home_dot_gyp):
             home_dot_gyp = None
@@ -476,7 +476,7 @@ def gyp_main(args):
 
   # If ~/.gyp/include.gypi exists, it'll be forcibly included into every
   # .gyp file that's loaded, before anything else is included.
-  if home_dot_gyp != None:
+  if home_dot_gyp is not None:
     default_include = os.path.join(home_dot_gyp, 'include.gypi')
     if os.path.exists(default_include):
       print 'Using overrides found in ' + default_include

--- a/tools/gyp/pylib/gyp/generator/ninja.py
+++ b/tools/gyp/pylib/gyp/generator/ninja.py
@@ -718,7 +718,7 @@ class NinjaWriter(object):
           elif var == 'name':
             extra_bindings.append(('name', cygwin_munge(basename)))
           else:
-            assert var == None, repr(var)
+            assert var is None, repr(var)
 
         outputs = [self.GypPathToNinja(o, env) for o in outputs]
         if self.flavor == 'win':

--- a/tools/gyp/pylib/gyp/generator/xcode.py
+++ b/tools/gyp/pylib/gyp/generator/xcode.py
@@ -535,7 +535,7 @@ def ExpandXcodeVariables(string, expansions):
   """
 
   matches = _xcode_variable_re.findall(string)
-  if matches == None:
+  if matches is None:
     return string
 
   matches.reverse()

--- a/tools/gyp/pylib/gyp/input.py
+++ b/tools/gyp/pylib/gyp/input.py
@@ -154,7 +154,7 @@ def GetIncludedBuildFiles(build_file_path, aux_data, included=None):
   in the list will be relative to the current directory.
   """
 
-  if included == None:
+  if included is None:
     included = []
 
   if build_file_path in included:
@@ -270,7 +270,7 @@ def LoadOneBuildFile(build_file_path, data, aux_data, includes,
 def LoadBuildFileIncludesIntoDict(subdict, subdict_path, data, aux_data,
                                   includes, check):
   includes_list = []
-  if includes != None:
+  if includes is not None:
     includes_list.extend(includes)
   if 'includes' in subdict:
     for include in subdict['includes']:
@@ -886,7 +886,7 @@ def ExpandVariables(input, phase, variables, build_file):
             replacement = str(py_module.DoMain(parsed_contents[1:])).rstrip()
           finally:
             os.chdir(oldwd)
-          assert replacement != None
+          assert replacement is not None
         elif command_string:
           raise GypError("Unknown command string '{0!s}' in '{1!s}'.".format(command_string, contents))
         else:
@@ -1050,7 +1050,7 @@ def EvalCondition(condition, conditions_key, phase, variables, build_file):
     else:
       false_dict = None
       i = i + 2
-    if result == None:
+    if result is None:
       result = EvalSingleCondition(
           cond_expr, true_dict, false_dict, phase, variables, build_file)
 
@@ -1129,7 +1129,7 @@ def ProcessConditionsInDict(the_dict, phase, variables, build_file):
     merge_dict = EvalCondition(condition, conditions_key, phase, variables,
                                build_file)
 
-    if merge_dict != None:
+    if merge_dict is not None:
       # Expand variables and nested conditinals in the merge_dict before
       # merging it.
       ProcessVariablesAndConditionsInDict(merge_dict, phase,
@@ -1590,12 +1590,12 @@ class DependencyGraphNode(object):
 
   def DirectDependencies(self, dependencies=None):
     """Returns a list of just direct dependencies."""
-    if dependencies == None:
+    if dependencies is None:
       dependencies = []
 
     for dependency in self.dependencies:
       # Check for None, corresponding to the root node.
-      if dependency.ref != None and dependency.ref not in dependencies:
+      if dependency.ref is not None and dependency.ref not in dependencies:
         dependencies.append(dependency.ref)
 
     return dependencies
@@ -1618,7 +1618,7 @@ class DependencyGraphNode(object):
     public entry point.
     """
 
-    if dependencies == None:
+    if dependencies is None:
       dependencies = []
 
     index = 0

--- a/tools/gyp/pylib/gyp/xcodeproj_file.py
+++ b/tools/gyp/pylib/gyp/xcodeproj_file.py
@@ -384,7 +384,7 @@ class XCObject(object):
     hashables = [self.__class__.__name__]
 
     name = self.Name()
-    if name != None:
+    if name is not None:
       hashables.append(name)
 
     hashables.extend(self._hashables)
@@ -630,7 +630,7 @@ class XCObject(object):
     else:
       raise TypeError("Can't make " + value.__class__.__name__ + ' printable')
 
-    if comment != None:
+    if comment is not None:
       printable += ' ' + self._EncodeComment(comment)
 
     return printable
@@ -926,11 +926,11 @@ class XCHierarchicalElement(XCObject):
       # the variable out and make the path be relative to that variable by
       # assigning the variable name as the sourceTree.
       (source_tree, path) = SourceTreeAndPathFromPath(self._properties['path'])
-      if source_tree != None:
+      if source_tree is not None:
         self._properties['sourceTree'] = source_tree
-      if path != None:
+      if path is not None:
         self._properties['path'] = path
-      if source_tree != None and path is None and \
+      if source_tree is not None and path is None and \
          not 'name' in self._properties:
         # The path was of the form "$(SDKROOT)" with no path following it.
         # This object is now relative to that variable, so it has no path
@@ -992,7 +992,7 @@ class XCHierarchicalElement(XCObject):
     # hashables, even though the paths aren't relative to their parents.  This
     # is not expected to be much of a problem in practice.
     path = self.PathFromSourceTreeAndPath()
-    if path != None:
+    if path is not None:
       components = path.split(posixpath.sep)
       for component in components:
         hashables.append(self.__class__.__name__ + '.path')
@@ -1083,9 +1083,9 @@ class XCHierarchicalElement(XCObject):
           (path is None or \
            (not path.startswith('/') and not path.startswith('$'))):
       this_path = xche.PathFromSourceTreeAndPath()
-      if this_path != None and path != None:
+      if this_path is not None and path is not None:
         path = posixpath.join(this_path, path)
-      elif this_path != None:
+      elif this_path is not None:
         path = this_path
       xche = xche.parent
 
@@ -1126,7 +1126,7 @@ class PBXGroup(XCHierarchicalElement):
     # children.
     for child in self._properties.get('children', []):
       child_name = child.Name()
-      if child_name != None:
+      if child_name is not None:
         hashables.append(child_name)
 
     return hashables
@@ -1256,14 +1256,14 @@ class PBXGroup(XCHierarchicalElement):
 
     path_split = path.split(posixpath.sep)
     if len(path_split) == 1 or \
-       ((is_dir or variant_name != None) and len(path_split) == 2) or \
+       ((is_dir or variant_name is not None) and len(path_split) == 2) or \
        not hierarchical:
       # The PBXFileReference or PBXVariantGroup will be added to or gotten from
       # this PBXGroup, no recursion necessary.
       if variant_name is None:
         # Add or get a PBXFileReference.
         file_ref = self.GetChildByPath(path)
-        if file_ref != None:
+        if file_ref is not None:
           assert file_ref.__class__ == PBXFileReference
         else:
           file_ref = PBXFileReference({'path': path})
@@ -1278,7 +1278,7 @@ class PBXGroup(XCHierarchicalElement):
             variant_group_name, grandparent)
         variant_path = posixpath.sep.join(path_split[-2:])
         variant_ref = variant_group_ref.GetChildByPath(variant_path)
-        if variant_ref != None:
+        if variant_ref is not None:
           assert variant_ref.__class__ == PBXFileReference
         else:
           variant_ref = PBXFileReference({'name': variant_name,
@@ -1294,7 +1294,7 @@ class PBXGroup(XCHierarchicalElement):
       # path component.
       next_dir = path_split[0]
       group_ref = self.GetChildByPath(next_dir)
-      if group_ref != None:
+      if group_ref is not None:
         assert group_ref.__class__ == PBXGroup
       else:
         group_ref = PBXGroup({'path': next_dir})
@@ -1322,7 +1322,7 @@ class PBXGroup(XCHierarchicalElement):
       return variant_group_ref
 
     variant_group_properties = {'name': name}
-    if path != None:
+    if path is not None:
       variant_group_properties['path'] = path
     variant_group_ref = PBXVariantGroup(variant_group_properties)
     self.AppendChild(variant_group_ref)
@@ -1382,7 +1382,7 @@ class PBXGroup(XCHierarchicalElement):
       # If the original parent had a name set, keep using it.  If the original
       # parent didn't have a name but the child did, let the child's name
       # live on.  If the name attribute seems unnecessary now, get rid of it.
-      if 'name' in old_properties and old_properties['name'] != None and \
+      if 'name' in old_properties and old_properties['name'] is not None and \
          old_properties['name'] != self.Name():
         self._properties['name'] = old_properties['name']
       if 'name' in self._properties and 'path' in self._properties and \
@@ -1423,7 +1423,7 @@ class XCFileLikeElement(XCHierarchicalElement):
 
     hashables = []
     xche = self
-    while xche != None and isinstance(xche, XCHierarchicalElement):
+    while xche is not None and isinstance(xche, XCHierarchicalElement):
       xche_hashables = xche.Hashables()
       for index in xrange(0, len(xche_hashables)):
         hashables.insert(index, xche_hashables[index])
@@ -1812,7 +1812,7 @@ class XCBuildPhase(XCObject):
     xcfilelikeelement = pbxbuildfile._properties['fileRef']
 
     paths = []
-    if path != None:
+    if path is not None:
       # It's best when the caller provides the path.
       if isinstance(xcfilelikeelement, PBXVariantGroup):
         paths.append(path)
@@ -2273,10 +2273,10 @@ class PBXNativeTarget(XCTarget):
        self._properties['productType'] in self._product_filetypes:
       products_group = None
       pbxproject = self.PBXProjectAncestor()
-      if pbxproject != None:
+      if pbxproject is not None:
         products_group = pbxproject.ProductsGroup()
 
-      if products_group != None:
+      if products_group is not None:
         (filetype, prefix, suffix) = \
             self._product_filetypes[self._properties['productType']]
         # Xcode does not have a distinct type for loadable modules that are
@@ -2604,7 +2604,7 @@ class PBXProject(XCContainerPortal):
     }
 
     (source_tree, path) = SourceTreeAndPathFromPath(path)
-    if source_tree != None and source_tree in source_tree_groups:
+    if source_tree is not None and source_tree in source_tree_groups:
       (group_func, hierarchical) = source_tree_groups[source_tree]
       group = group_func()
       return (group, hierarchical)


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:runt18:node?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:runt18:node?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
